### PR TITLE
Use safe area for add alarm screen

### DIFF
--- a/client/components/AlarmClock.tsx
+++ b/client/components/AlarmClock.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, Modal, Platform, Button } from 'react-native';
+import { View, Text, TouchableOpacity, Modal, Platform, Button, SafeAreaView } from 'react-native';
 import { styles, textStyles } from '../styles';
 import { getDynamicStyles } from '../styles/AlarmStyles';
 import { useDarkMode } from '../contexts/DarkModeContext';
@@ -147,8 +147,9 @@ function AlarmClock({ onAlarmSave, editingAlarm }: AlarmClockProps) {
         visible={isAlarmSettingVisible}
         onRequestClose={closeAlarmSetting}
         style={dynamicStyles.modalContainer}
+        presentationStyle='pageSheet'
       >
-        <View style={{ flex: 1, paddingTop: 22 }}>
+        <SafeAreaView style={{ flex: 1, paddingTop: 22 }}>
           <View style={dynamicStyles.topNavBar}>
             <TouchableOpacity onPress={closeAlarmSetting}>
               <Text style={dynamicStyles.topBarText}>Cancel</Text>
@@ -175,7 +176,7 @@ function AlarmClock({ onAlarmSave, editingAlarm }: AlarmClockProps) {
           <SoundPicker /* pass any props needed */ />
           <SnoozeSwitch isSnoozeEnabled={isSnoozeEnabled} setIsSnoozeEnabled={setIsSnoozeEnabled} />
           <Button title="Schedule Notification" onPress={scheduleNotification} />
-        </View>
+        </SafeAreaView>
       </Modal>
     </View>
   );


### PR DESCRIPTION
Minor fix for issue where on some devices (e.g. iOS) the top of the add alarm screen goes outside the safe area and is obstructed

Also set `presentationStyle` to make experience on iOS more consistent with similar sheets

<img width="559" alt="Screenshot 2024-09-17 at 6 36 37 PM" src="https://github.com/user-attachments/assets/1d032a3f-e462-4dbe-9a9c-f66dc868f9e2">

<img width="559" alt="Screenshot 2024-09-17 at 6 38 52 PM" src="https://github.com/user-attachments/assets/b9cbc969-0c20-4ef0-bc68-78862eeffd69">
